### PR TITLE
changing the caption_new_speaker_turn_pattern parameter

### DIFF
--- a/python/event-gather-config.json
+++ b/python/event-gather-config.json
@@ -2,7 +2,7 @@
     "google_credentials_file": "google-creds.json",
     "get_events_function_path": "cdp_oakland_backend.scraper.get_events",
     "gcs_bucket_name": null,
-    "caption_new_speaker_turn_pattern": null,
+    "caption_new_speaker_turn_pattern": ">",
     "caption_confidence": null,
     "default_event_gather_from_days_timedelta": 6
 }


### PR DESCRIPTION
The Oregon separator between speakers is `>>` as opposed to `&gt;` in other instances. This PR addresses this difference